### PR TITLE
Update SCAPI sample with "interaction.consult()", "interaction.singleStepTransfer()", "interaction.singleStepConference()", "interaction.completeTransfer()", "interaction.completeConference()" and "voice.dialEx()".

### DIFF
--- a/wwe-service-client-api/api-overview/sample.html
+++ b/wwe-service-client-api/api-overview/sample.html
@@ -107,9 +107,33 @@
           command = 'genesys.wwe.service.interaction.reject("1", succeeded, failed)';
           commandHelp = 'Reject the interaction.';
           break;
+        case 'interaction.singleStepTransfer':
+          command = 'genesys.wwe.service.interaction.singleStepTransfer("1", { type: "AGENT", destination: "SIP_5001" }, { k1: "v1", k2: "v2" }, { ek1: "ev1", ek2: "ev2" }, succeeded, failed)';
+          commandHelp = 'Single step transfer the interaction.';
+          break;
+        case 'interaction.singleStepConference':
+          command = 'genesys.wwe.service.interaction.singleStepConference("1", { type: "AGENT", destination: "SIP_5001" }, { k1: "v1", k2: "v2" }, { ek1: "ev1", ek2: "ev2" }, succeeded, failed)';
+          commandHelp = 'Single step conference the interaction.';
+          break;
+        case 'interaction.consult':
+          command = 'genesys.wwe.service.interaction.consult("1", { type: "AGENT", destination: "SIP_5001", media: "voice" }, { k1: "v1", k2: "v2" }, { ek1: "ev1", ek2: "ev2" }, succeeded, failed)';
+          commandHelp = 'Consult the interaction.';
+          break;
+        case 'interaction.completeTransfer':
+          command = 'genesys.wwe.service.interaction.completeTransfer("2", succeeded, failed)';
+          commandHelp = 'Complete transfer the interaction.';
+          break;
+        case 'interaction.completeConference':
+          command = 'genesys.wwe.service.interaction.completeConference("2", succeeded, failed)';
+          commandHelp = 'Complete conference the interaction.';
+          break;
         case 'voice.dial':
           command = 'genesys.wwe.service.voice.dial("*PhoneNumber*", { myAttachedDataKey1: "myAttachedDataValue1", myAttachedDataKey2: "myAttachedDataValue2" }, succeeded, failed)';
           commandHelp = 'Call the destination with the optional attached data.';
+          break;
+        case 'voice.dialEx':
+          command = 'genesys.wwe.service.voice.dialEx("*PhoneNumber*", { myAttachedDataKey1: "myAttachedDataValue1", myAttachedDataKey2: "myAttachedDataValue2" }, { myExtensionKey1: "myExtensionValue1", myExtensionKey2: "myExtensionValue2" }, succeeded, failed)';
+          commandHelp = 'Call the destination with the attached data and extensions.';
           break;
         case 'voice.answer':
           command = 'genesys.wwe.service.voice.answer("1", succeeded, failed)';
@@ -309,7 +333,7 @@
   width: "430px",\n\
   height: "40%"\n\
 }, succeeded, failed)';
-          commandHelp = "Open a customizable dialog.";
+          commandHelp = 'Open a customizable dialog.';
           break;
         case 'system.closeDialog':
           command = 'genesys.wwe.service.system.closeDialog("wweCustomDialog1", succeeded, failed)';
@@ -422,8 +446,14 @@
     <button onclick="showCommand('interaction.unblockMarkdone')">interaction.unblockMarkdone</button>
     <button onclick="showCommand('interaction.accept')">interaction.accept</button>
     <button onclick="showCommand('interaction.reject')">interaction.reject</button>
+    <button onclick="showCommand('interaction.singleStepTransfer')">interaction.singleStepTransfer</button>
+    <button onclick="showCommand('interaction.singleStepConference')">interaction.singleStepConference</button>
+    <button onclick="showCommand('interaction.consult')">interaction.consult</button>
+    <button onclick="showCommand('interaction.completeTransfer')">interaction.completeTransfer</button>
+    <button onclick="showCommand('interaction.completeConference')">interaction.completeConference</button>
     <br>
     <button onclick="showCommand('voice.dial')">voice.dial</button>
+    <button onclick="showCommand('voice.dialEx')">voice.dialEx</button>
     <button onclick="showCommand('voice.answer')">voice.answer</button>
     <button onclick="showCommand('voice.hold')">voice.hold</button>
     <button onclick="showCommand('voice.resume')">voice.resume</button>

--- a/wwe-service-client-api/api-overview/wwe-service-client-api.js
+++ b/wwe-service-client-api/api-overview/wwe-service-client-api.js
@@ -348,6 +348,36 @@ if (!window.genesys.wwe.service) {
         request: 'interaction.reject',
         parameters: [interactionId]
       }, successCallback, failedCallback);
+    },
+    singleStepTransfer: function (interactionId, target, userData, extensions, successCallback, failedCallback) {
+      service.sendMessage({
+        request: 'interaction.singleStepTransfer',
+        parameters: [interactionId, target, userData, extensions]
+      }, successCallback, failedCallback);
+    },
+    singleStepConference: function (interactionId, target, userData, extensions, successCallback, failedCallback) {
+      service.sendMessage({
+        request: 'interaction.singleStepConference',
+        parameters: [interactionId, target, userData, extensions]
+      }, successCallback, failedCallback);
+    },
+    consult: function (interactionId, target, userData, extensions, successCallback, failedCallback) {
+      service.sendMessage({
+        request: 'interaction.consult',
+        parameters: [interactionId, target, userData, extensions]
+      }, successCallback, failedCallback);
+    },
+    completeTransfer: function (consultInteractionId, successCallback, failedCallback) {
+      service.sendMessage({
+        request: 'interaction.completeTransfer',
+        parameters: [consultInteractionId]
+      }, successCallback, failedCallback);
+    },
+    completeConference: function (consultInteractionId, successCallback, failedCallback) {
+      service.sendMessage({
+        request: 'interaction.completeConference',
+        parameters: [consultInteractionId]
+      }, successCallback, failedCallback);
     }
   };
 
@@ -362,6 +392,9 @@ if (!window.genesys.wwe.service) {
         request: 'voice.dial',
         parameters: [destination, userData]
       }, successCallback, failedCallback);
+    },
+    dialEx: function (destination, userData, extensions, successCallback, failedCallback) {
+      service.sendMessage({ request: "voice.dialEx", parameters: [destination, userData, extensions] }, successCallback, failedCallback);
     },
     answer: function (interactionId, successCallback, failedCallback) {
       service.sendMessage({


### PR DESCRIPTION
Depending on the media, from SCAPI, it is now possible to make a single step transfer, a single step conference, a consultation, and to complete a consultation to a transfer or a conference. For "interaction.consult()", "interaction.singleStepTransfer()" and "interaction.singleStepConference()", the parameters are almost the same.

It adds also the SCAPI method: "voice.dialEx()" which adds the parameters "extensions" to the existing SCAPI method: "voice.dial(destination, userData, succeeded, failed)".

Methods:

* interaction.singleStepTransfer(interactionId, targetQuery, userData, extensions, succeeded, failed)
    Make a single step transfer.
    Parameters:
    ** interactionId: The interaction id of the interaction.
    ** targetQuery: The destination target object, or a phone number as a character string.
        If targetQuery is a character string, we create the operation uses a target of type CustomContact with a destination set to this value.
        If it is a JSON object, there are several sub parameters:
        *** type: The target type. The possible values are: "AGENT", "AGENT_GROUP", "SKILL", "INTERACTION_QUEUE", "ROUTING_POINT", "CUSTOM_CONTACT".
        *** destination: The destination. This value is the employeeId for an agent, the name of an AgentGroup, the name of a Skill, the name of an InteractionQueue, the name of a RoutingPoint, a phone number for CustomContact.
    ** userData: The attached user data key/value object. Set an undefined or empty JSON object to not set the user data.
    ** extensions: The extensions key/value object. Set an undefined or empty JSON object to not set the extensions.
    ** succeeded: A function called when the operation succeeds.
    ** failed: A function called when the operation fails.

* interaction.singleStepConference(interactionId, targetQuery, userData, extensions, succeeded, failed)
    Make a single step conference.
    Parameters:
    ** interactionId: The interaction id of the interaction.
    ** targetQuery: The destination target object, or a phone number as a character string.
        If targetQuery is a character string, we create the operation uses a target of type CustomContact with a destination set to this value.
        If it is a JSON object, there are several sub parameters:
        *** type: The target type. The possible values are: "AGENT", "AGENT_GROUP", "SKILL", "INTERACTION_QUEUE", "ROUTING_POINT", "CUSTOM_CONTACT".
        *** destination: The destination. This value is the employeeId for an agent, the name of an AgentGroup, the name of a Skill, the name of an InteractionQueue, the name of a RoutingPoint, a phone number for CustomContact.
    ** userData: The attached user data key/value object. Set an undefined or empty JSON object to not set the user data.
    ** extensions: The extensions key/value object. Set an undefined or empty JSON object to not set the extensions. This does not apply for the chat media.
    ** succeeded: A function called when the operation succeeds.
    ** failed: A function called when the operation fails.

* interaction.consult(interactionId, targetQuery, userData, extensions, succeeded, failed)
    Make a consultation.
    Parameters:
    ** interactionId: The interaction id of the interaction.
    ** targetQuery: The destination target object, or a phone number as a character string.
        If targetQuery is a character string, we create the operation uses a target of type CustomContact with a destination set to this value.
        If it is a JSON object, there are several sub parameters:
        *** type: The target type. The possible values are: "AGENT", "AGENT_GROUP", "SKILL", "INTERACTION_QUEUE", "ROUTING_POINT", "CUSTOM_CONTACT".
        *** destination: The destination. This value is the employeeId for an agent, the name of an AgentGroup, the name of a Skill, the name of an InteractionQueue, the name of a RoutingPoint, a phone number for CustomContact.
        *** [media]: An optional media used to make the consultation. If not specified, uses the same media as the specified interaction. For example, if the interaction has a "chat" media, and you want to make a voice consultation, you must specify "voice" here.
    ** userData: The attached user data key/value object. Set an undefined or empty JSON object to not set the user data.
    ** extensions: The extensions key/value object. Set an undefined or empty JSON object to not set the extensions. This does not apply for the chat media.
    ** succeeded: A function called when the operation succeeds.
    ** failed: A function called when the operation fails.

* interaction.completeTransfer(consultInteractionId, succeeded, failed)
    Complete a transfer.
    Parameters:
    ** consultInteractionId: The interaction id of the consultation.
    ** succeeded: A function called when the operation succeeds.
    ** failed: A function called when the operation fails.

* interaction.completeConference(consultInteractionId, succeeded, failed)
    Complete a conference.
    Parameters:
    ** consultInteractionId: The interaction id of the consultation.
    ** succeeded: A function called when the operation succeeds.
    ** failed: A function called when the operation fails.

* voice.dialEx(destination, userData, extensions, succeeded, failed)
    Calls the destination with the attached data and extensions with the following parameters:
    Parameters:
    ** destination: The call destination number.
    ** userData: The attached user data key/value object. Set an undefined or empty JSON object to not set the user data.
    ** extensions: The extensions key/value object. Set an undefined or empty JSON object to not set the extensions.
    ** succeeded: A function called when the operation succeeds.
    ** failed: A function called when the operation fails.